### PR TITLE
bumped pyopenssl version to 22

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -11,7 +11,7 @@ iso8601==1.0.2
 jsonschema==4.0.1
 markdown==3.3.4
 pip-chill==1.0.1
-pyopenssl==21.0.0
+pyopenssl==22.0.0
 pyyaml==5.4.1
 service-identity==21.1.0
 whitenoise==5.3.0


### PR DESCRIPTION
in order to provide Python 3.10 support
fixes #17