### PR TITLE
Resolves undefined 'server' variable - Fix #31

### DIFF
--- a/free/templates/free/layout/scripts.html
+++ b/free/templates/free/layout/scripts.html
@@ -26,6 +26,6 @@
 
 <script src="{% static 'free/js/elab-layout.js' %}" ></script> 
 
-<script src="{% static 'free/js/janus.js' %}" ></script> 
-<script src="{% static 'free/js/streaming_simple.js' %}" ></script> 
+<!--<script src="{% static 'free/js/janus.js' %}" ></script>-->
+<!--<script src="{% static 'free/js/streaming_simple.js' %}" ></script>-->
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/webrtc-adapter/8.0.0/adapter.min.js" ></script>


### PR DESCRIPTION
avoids undefined "server" variable error in javascript (client side).