### PR TITLE
Fixes crashes during user creation.

### DIFF
--- a/free/admin.py
+++ b/free/admin.py
@@ -72,6 +72,8 @@ class UserAdmin(BaseUserAdmin):
     def get_form(self, request, obj=None, **kwargs):
         if obj:
             self.inlines = (UserProfileInline,)
+        else:
+            self.inlines = ()
         return super().get_form(request, obj, **kwargs)
 
 admin.site.unregister(User)


### PR DESCRIPTION
The problem is, that the form showing selection of Student/Teacher/Administrator should only be visible during the second step of user creation (or user edit). Inputting anything into this form during first step of user creation crashes the app.

Closes #37.

I propose to merge this into master branch and release a bugfix version of 0.5.1.