### PR TITLE
changed drf-yasg version again

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -5,7 +5,7 @@ django-react-components==0.1.3a0
 django-summernote==0.8.20.0
 django-tables2==2.4.1
 django-webpack-loader==1.3.0
-drf-yasg==1.20.0
+drf-yasg>=1.20.0
 future==0.18.2
 iso8601==1.0.2
 jsonschema==4.0.1


### PR DESCRIPTION
Use drf-yasg>=1.20.0 instead of drf-yasg==1.20.0 to avoid the following error: `ImportError: Module "drf_yasg.generators" does not define a "OpenAPISchemaGenerator" attribute/class`