### PR TITLE
Bump pyopenssl version to fix #51

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -12,7 +12,7 @@ jsonschema==4.0.1
 markdown==3.3.4
 Pillow==9.2.0
 pip-chill==1.0.1
-pyopenssl==22.0.0
+pyopenssl==23.0.0
 pyyaml==5.4.1
 service-identity==21.1.0
 whitenoise==5.3.0


### PR DESCRIPTION
This pull request bumps pyopenssl version to fix dependency conflict in some environments as described in #51.